### PR TITLE
Add throttle pressed detection

### DIFF
--- a/components/adas-pwm-driver/ adas_pwm_driver.cpp
+++ b/components/adas-pwm-driver/ adas_pwm_driver.cpp
@@ -157,7 +157,10 @@ namespace adas
     esp_err_t PwmPassthroughChannel::start()
     {
         return input_->start([this](float duty)
-                             { output_->setDuty(duty); });
+                             {
+                                 last_duty_ = duty;
+                                 output_->setDuty(duty);
+                             });
     }
 
     esp_err_t PwmPassthroughChannel::stop()
@@ -168,6 +171,13 @@ namespace adas
     esp_err_t PwmPassthroughChannel::setDuty(float duty)
     {
         return output_->setDuty(duty);
+    }
+
+    bool PwmPassthroughChannel::throttlePressed(float center, float range) const
+    {
+        float lower = center - range * 0.5f;
+        float upper = center + range * 0.5f;
+        return last_duty_ < lower || last_duty_ > upper;
     }
 
     // ------------ PwmDriver ------------

--- a/components/adas-pwm-driver/include/adas_pwm_driver.hpp
+++ b/components/adas-pwm-driver/include/adas_pwm_driver.hpp
@@ -84,10 +84,19 @@ namespace adas
         esp_err_t stop();
         esp_err_t setDuty(float duty);
 
+        /// Return last duty captured by RMT input (absolute duty ratio).
+        float lastDuty() const { return last_duty_; }
+
+        /// Check if throttle is pressed outside neutral range.
+        /// @param center duty ratio considered neutral (default 9%)
+        /// @param range width of neutral band (default 1%)
+        bool throttlePressed(float center = 0.09f, float range = 0.01f) const;
+
     private:
         PwmChannelConfig cfg_;
         std::unique_ptr<RmtInput> input_;
         std::unique_ptr<LedcOutput> output_;
+        float last_duty_ = 0.0f;
     };
 
     class PwmDriver
@@ -115,6 +124,16 @@ namespace adas
             if (idx >= channels_.size())
                 return ESP_ERR_INVALID_ARG;
             return channels_[idx]->start(); // leaves LEDC untouched
+        }
+
+        /// Return true if throttle channel idx is pressed outside neutral band
+        bool isThrottlePressed(size_t idx,
+                              float center = 0.09f,
+                              float range = 0.01f) const
+        {
+            if (idx >= channels_.size())
+                return false;
+            return channels_[idx]->throttlePressed(center, range);
         }
 
     private:


### PR DESCRIPTION
## Summary
- extend PWM passthrough driver with ability to query throttle state

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b5f7cea88326a043f98e7af0cecc