### PR TITLE
Handle multiple PWM pause/resume calls

### DIFF
--- a/components/adas-pwm-driver/adas_pwm_driver.cpp
+++ b/components/adas-pwm-driver/adas_pwm_driver.cpp
@@ -31,6 +31,10 @@ namespace adas
 
     esp_err_t RmtInput::start(DutyCallback cb)
     {
+        if (running_)
+        {
+            return ESP_OK;
+        }
         callback_ = std::move(cb);
         queue_ = xQueueCreate(3, sizeof(rmt_rx_done_event_data_t));
         rmt_rx_event_callbacks_t cbs = {.on_recv_done = onRecvDone};
@@ -56,6 +60,7 @@ namespace adas
             return ESP_FAIL;
         }
 
+        running_ = true;
         return ESP_OK;
 
         // return xTaskCreate(
@@ -66,6 +71,10 @@ namespace adas
 
     esp_err_t RmtInput::stop()
     {
+        if (!running_)
+        {
+            return ESP_OK;
+        }
         if (task_handle_)
         {
             vTaskDelete(task_handle_);
@@ -80,6 +89,7 @@ namespace adas
             vQueueDelete(queue_);
             queue_ = nullptr;
         }
+        running_ = false;
         return ESP_OK;
     }
 
@@ -149,23 +159,42 @@ namespace adas
     {
     }
 
-    PwmPassthroughChannel::~PwmPassthroughChannel()
-    {
-        stop();
-    }
+PwmPassthroughChannel::~PwmPassthroughChannel()
+{
+    stop();
+}
 
-    esp_err_t PwmPassthroughChannel::start()
+esp_err_t PwmPassthroughChannel::start()
+{
+    if (running_)
     {
-        return input_->start([this](float duty)
-                             {
-                                 last_duty_ = duty;
-                                 output_->setDuty(duty); });
+        return ESP_OK;
     }
+    esp_err_t err = input_->start([this](float duty)
+                                  {
+                                      last_duty_ = duty;
+                                      output_->setDuty(duty);
+                                  });
+    if (err == ESP_OK)
+    {
+        running_ = true;
+    }
+    return err;
+}
 
-    esp_err_t PwmPassthroughChannel::stop()
+esp_err_t PwmPassthroughChannel::stop()
+{
+    if (!running_)
     {
-        return input_->stop();
+        return ESP_OK;
     }
+    esp_err_t err = input_->stop();
+    if (err == ESP_OK)
+    {
+        running_ = false;
+    }
+    return err;
+}
 
     esp_err_t PwmPassthroughChannel::setDuty(float duty)
     {

--- a/components/adas-pwm-driver/include/adas_pwm_driver.hpp
+++ b/components/adas-pwm-driver/include/adas_pwm_driver.hpp
@@ -57,6 +57,7 @@ namespace adas
         std::vector<rmt_symbol_word_t> buffer_;
         DutyCallback callback_;
         static constexpr size_t DEFAULT_BUFFER = 64;
+        bool running_ = false;
     };
 
     class LedcOutput : public IPwmChannel
@@ -97,6 +98,7 @@ namespace adas
         std::unique_ptr<RmtInput> input_;
         std::unique_ptr<LedcOutput> output_;
         float last_duty_ = 0.0f;
+        bool running_ = false;
     };
 
     class PwmDriver


### PR DESCRIPTION
## Summary
- add `running_` flag to `RmtInput` and `PwmPassthroughChannel`
- ignore repeated calls to start/stop when channel already in that state

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866165fa2048326a619e4f4b4d9ff02