### PR TITLE
Add minimal BMI270 sensor component and test

### DIFF
--- a/components/bmi270-sensor/CMakeLists.txt
+++ b/components/bmi270-sensor/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "bmi270_sensor.cpp" \
+                       INCLUDE_DIRS "include")

--- a/components/bmi270-sensor/bmi270_sensor.cpp
+++ b/components/bmi270-sensor/bmi270_sensor.cpp
@@ -1,0 +1,93 @@
+#include "bmi270_sensor.hpp"
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+namespace bmi270_sensor {
+
+static const char *TAG = "BMI270";
+
+namespace {
+constexpr uint8_t REG_CHIP_ID    = 0x00;
+constexpr uint8_t REG_CMD        = 0x7E;
+constexpr uint8_t REG_ACC_CONF   = 0x40;
+constexpr uint8_t REG_ACC_RANGE  = 0x41;
+constexpr uint8_t REG_DATA_START = 0x12;
+constexpr uint8_t CHIP_ID        = 0x24;
+constexpr uint8_t CMD_SOFT_RESET = 0xB6;
+} // namespace
+
+esp_err_t Bmi270Sensor::write_reg(uint8_t reg, uint8_t value)
+{
+    uint8_t buf[2] = {reg, value};
+    return i2c_master_write_to_device(PORT, ADDR, buf, sizeof(buf),
+                                      pdMS_TO_TICKS(100));
+}
+
+esp_err_t Bmi270Sensor::read_regs(uint8_t reg, uint8_t *data, size_t len)
+{
+    return i2c_master_write_read_device(PORT, ADDR, &reg, 1, data, len,
+                                        pdMS_TO_TICKS(100));
+}
+
+esp_err_t Bmi270Sensor::init()
+{
+    i2c_config_t cfg{};
+    cfg.mode = I2C_MODE_MASTER;
+    cfg.sda_io_num = SDA;
+    cfg.scl_io_num = SCL;
+    cfg.sda_pullup_en = GPIO_PULLUP_ENABLE;
+    cfg.scl_pullup_en = GPIO_PULLUP_ENABLE;
+    cfg.master.clk_speed = 400000;
+    esp_err_t err = i2c_param_config(PORT, &cfg);
+    if (err != ESP_OK)
+        return err;
+    err = i2c_driver_install(PORT, cfg.mode, 0, 0, 0);
+    if (err != ESP_OK)
+        return err;
+
+    // allow sensor to power up
+    vTaskDelay(pdMS_TO_TICKS(2));
+
+    uint8_t id = 0;
+    err = read_regs(REG_CHIP_ID, &id, 1);
+    if (err != ESP_OK)
+        return err;
+    if (id != CHIP_ID)
+    {
+        ESP_LOGE(TAG, "Unexpected chip id 0x%02X", id);
+        return ESP_FAIL;
+    }
+
+    err = write_reg(REG_CMD, CMD_SOFT_RESET);
+    if (err != ESP_OK)
+        return err;
+    vTaskDelay(pdMS_TO_TICKS(10));
+
+    err = write_reg(REG_ACC_CONF, 0x08); // 100 Hz
+    if (err != ESP_OK)
+        return err;
+    err = write_reg(REG_ACC_RANGE, 0x01); // 4G
+    if (err != ESP_OK)
+        return err;
+    scale_ = 9.80665f * 4.0f / 32768.0f;
+
+    return ESP_OK;
+}
+
+esp_err_t Bmi270Sensor::read_accel(float &x, float &y, float &z)
+{
+    uint8_t buf[6];
+    esp_err_t err = read_regs(REG_DATA_START, buf, sizeof(buf));
+    if (err != ESP_OK)
+        return err;
+    int16_t raw_x = int16_t(buf[0] | (buf[1] << 8));
+    int16_t raw_y = int16_t(buf[2] | (buf[3] << 8));
+    int16_t raw_z = int16_t(buf[4] | (buf[5] << 8));
+    x = raw_x * scale_;
+    y = raw_y * scale_;
+    z = raw_z * scale_;
+    return ESP_OK;
+}
+
+} // namespace bmi270_sensor

--- a/components/bmi270-sensor/idf_component.yml
+++ b/components/bmi270-sensor/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/bmi270: "1.1.0~2"

--- a/components/bmi270-sensor/include/bmi270_sensor.hpp
+++ b/components/bmi270-sensor/include/bmi270_sensor.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <driver/i2c.h>
+#include <esp_err.h>
+
+namespace bmi270_sensor {
+
+class Bmi270Sensor {
+public:
+    esp_err_t init();
+    esp_err_t read_accel(float &x, float &y, float &z);
+
+private:
+    static constexpr i2c_port_t PORT = I2C_NUM_0;
+    static constexpr gpio_num_t SDA = GPIO_NUM_4;
+    static constexpr gpio_num_t SCL = GPIO_NUM_5;
+    static constexpr uint8_t ADDR = 0x68;
+
+    float scale_ = 9.80665f * 2.0f / 32768.0f;
+
+    esp_err_t write_reg(uint8_t reg, uint8_t value);
+    esp_err_t read_regs(uint8_t reg, uint8_t *data, size_t len);
+};
+
+} // namespace bmi270_sensor

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "main.cpp"
-                       PRIV_REQUIRES spi_flash lidar-driver driver esp_timer adas-pwm-driver monitor
+                       PRIV_REQUIRES spi_flash lidar-driver driver esp_timer adas-pwm-driver monitor bmi270-sensor
                        INCLUDE_DIRS "")

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3,6 +3,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include "adas_pwm_driver.hpp"
+#include "bmi270_sensor.hpp"
 #include "LiDARConfig.hpp"
 #include "LiDAR.hpp"
 #include "Monitor.hpp"
@@ -94,6 +95,34 @@ static void ControlTask(void *pv)
 
 extern "C" void app_main()
 {
+    // --- BMI270 sensor test ---
+    static bmi270_sensor::Bmi270Sensor bmi;
+    if (bmi.init() == ESP_OK)
+    {
+        ESP_LOGI(TAG, "BMI270 initialized");
+        while (true)
+        {
+            float ax, ay, az;
+            if (bmi.read_accel(ax, ay, az) == ESP_OK)
+            {
+                ESP_LOGI(TAG, "Accel X: %.2f m/s^2 Y: %.2f m/s^2 Z: %.2f m/s^2", ax, ay, az);
+            }
+            else
+            {
+                ESP_LOGE(TAG, "Failed to read accel data");
+            }
+            vTaskDelay(pdMS_TO_TICKS(500));
+        }
+    }
+    else
+    {
+        ESP_LOGE(TAG, "BMI270 initialization failed");
+        while (true)
+        {
+            vTaskDelay(pdMS_TO_TICKS(1000));
+        }
+    }
+
     // --- LiDAR hardware setup ---
     LiDARConfig cfg = {
         .uartPort = UART_NUM_1,


### PR DESCRIPTION
## Summary
- add new bmi270-sensor component with basic I2C init, configuration and accel reading
- expose bmi270 component dependency for future enhancements
- exercise BMI270 driver in `app_main` and halt before existing logic

## Testing
- `idf.py reconfigure` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_6899ebfca1f4832690f7d9cfcb902c1b